### PR TITLE
Created alt govt for Bounty Cleanup

### DIFF
--- a/data/New Remnant Governments.txt
+++ b/data/New Remnant Governments.txt
@@ -1,0 +1,13 @@
+government "Korath (Berserk)"
+	swizzle 0
+	color .8 .5 .1
+	language "Korath"
+	
+	"attitude toward"
+		"Kor Sestor" -1
+		"Korath" 1
+		"Remnant" -1
+		"Merchant" -1
+		"Neutral" -1
+	
+	"player reputation" -20

--- a/data/New Remnant Missions.txt
+++ b/data/New Remnant Missions.txt
@@ -9,12 +9,12 @@ mission "Remnant: Clean-up Bounty"
 		has "Remnant: Defense 2: done"
 		random < 50
 	npc kill
-		government Korath
+		government "Korath (Berserk)"
 		personality coward target uninterested marked waiting
 		system
 			distance 1 2
 		fleet 4
-			names "korath"
+			names "Korath (Berserk)"
 			cargo 3
 			variant
 				"Korath Chaser"


### PR DESCRIPTION
ES was "losing" some Korath Chasers when they were picked up by Raiders, so they disappeared from the game making some clean up missions un completeable until the game was reloaded. This solves that problem.

That being said, having Raiders move the chasers around was a neat twist, so if the underlying "loosing ships" gets fixed, this change should be reversed.